### PR TITLE
Organization register parameters

### DIFF
--- a/src/components/pages/DAOcreator/ReviewStep.tsx
+++ b/src/components/pages/DAOcreator/ReviewStep.tsx
@@ -176,7 +176,9 @@ const displayFounder = ({ address, reputation, tokens }: Founder) => (
 
 const displayScheme = (schemeConfig: SchemeConfig) => {
   const votingMachine =
-    votingMachines[schemeConfig.params.votingMachineConfig.typeName]
+    votingMachines[
+      R.pathOr(null, ["votingMachineConfig", "typeName"], schemeConfig.params)
+    ]
   const scheme = getScheme(schemeConfig.typeName)
   return (
     <Grid container spacing={16} key={`scheme-${scheme.typeName}`}>
@@ -186,12 +188,16 @@ const displayScheme = (schemeConfig: SchemeConfig) => {
           <i>{scheme.description}</i>
         </Typography>
       </Grid>
-      <Grid item xs={12}>
-        <Typography variant="subtitle2">{votingMachine.displayName}</Typography>
-        <Typography>
-          <i>{votingMachine.description}</i>
-        </Typography>
-      </Grid>
+      {votingMachine != null ? (
+        <Grid item xs={12}>
+          <Typography variant="subtitle2">
+            {votingMachine.displayName}
+          </Typography>
+          <Typography>
+            <i>{votingMachine.description}</i>
+          </Typography>
+        </Grid>
+      ) : null}
     </Grid>
   )
 }

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -113,10 +113,13 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     const { name, value } = event.target
     const oldVotingMachineConfig = this.state.schemeConfig.params
       .votingMachineConfig
-    const newVotingMachineConfig: VotingMachineConfiguration = {
-      typeName: oldVotingMachineConfig.typeName,
-      params: R.assoc(name, value, oldVotingMachineConfig.params),
-    }
+    const newVotingMachineConfig =
+      oldVotingMachineConfig != null
+        ? {
+            typeName: oldVotingMachineConfig.typeName,
+            params: R.assoc(name, value, oldVotingMachineConfig.params),
+          }
+        : { typeName: "", params: [] }
     await this.addOrUpdateSchemeParam(
       "votingMachineConfig",
       newVotingMachineConfig
@@ -386,8 +389,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
             scheme.params
           )
         : null
-    const votingMachineConfig: VotingMachineConfiguration = schemeConfig.params
-      .votingMachineConfig || {
+    const votingMachineConfig = schemeConfig.params.votingMachineConfig || {
       typeName: "",
       params: [],
     }
@@ -412,9 +414,12 @@ class VerticalLinearStepper extends React.Component<Props, State> {
 
               {scheme != null && shouldHaveVotingMachine
                 ? [
-                    this.selectVotingMachineStep(votingMachineConfig, classes),
+                    this.selectVotingMachineStep(
+                      votingMachineConfig as VotingMachineConfiguration,
+                      classes
+                    ),
                     this.configureVotingMachineStep(
-                      votingMachineConfig,
+                      votingMachineConfig as VotingMachineConfiguration,
                       classes
                     ),
                   ]

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -27,6 +27,7 @@ import {
   getVotingMachine,
   getVotingMachineDefaultParams,
   schemes,
+  Scheme,
   SchemeConfig,
   VotingMachineConfiguration,
   votingMachines,
@@ -124,7 +125,6 @@ class VerticalLinearStepper extends React.Component<Props, State> {
 
   handleVotingMachineTypeChange = async (event: any) => {
     const { value: newTypeName } = event.target
-    const { params } = this.state.schemeConfig.params.votingMachineConfig
     const newVotingMachineConfig: VotingMachineConfiguration = {
       typeName: newTypeName,
       params: getVotingMachineDefaultParams(newTypeName),
@@ -151,15 +151,12 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     const { schemeConfig } = this.state
     const { typeName: schemeTypeName, params: schemeParams } = schemeConfig
     const { votingMachineConfig } = schemeParams
-    if (
-      !R.isEmpty(schemeTypeName) &&
-      !R.isEmpty(votingMachineConfig.typeName)
-    ) {
+    if (!R.isEmpty(schemeTypeName)) {
       this.props.addScheme(schemeConfig)
       this.handleClose()
     } else {
       throw Error(
-        "There is a bug; it should not be possible to call 'handleSave' when 'schemeType' and/or 'votingMAchineCinfig' are undefined"
+        "There is a bug; it should not be possible to call 'handleSave' when 'schemeType' is undefined"
       )
     }
   }
@@ -200,13 +197,200 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     </div>
   )
 
+  selectSchemeStep = (scheme: Scheme | null, classes: any) => (
+    <Step key={"selectSchemeStep"}>
+      <StepLabel>Select Scheme</StepLabel>
+      <StepContent>
+        <FormControl className={classes.formControl}>
+          <InputLabel htmlFor="scheme-select">Scheme</InputLabel>
+          <Select
+            className={classes.select}
+            value={scheme != null ? scheme.typeName : ""}
+            onChange={this.setSchemeType}
+            inputProps={{
+              name: "Scheme",
+              id: "scheme-select",
+            }}
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            {R.map(
+              scheme => (
+                <MenuItem
+                  value={scheme.typeName}
+                  key={"select-item-" + scheme.typeName}
+                >
+                  {scheme.displayName}
+                </MenuItem>
+              ),
+              schemes
+            )}
+          </Select>
+        </FormControl>
+        {scheme != null ? (
+          <Typography className={classes.description}>
+            {scheme.description}
+          </Typography>
+        ) : null}
+        {this.stepControlls(true, false, scheme != null, classes)}
+      </StepContent>
+    </Step>
+  )
+  configureSchemeStep = (
+    scheme: Scheme | null,
+    schemeConfig: SchemeConfig,
+    isLastStep: boolean,
+    classes: any
+  ) => {
+    const schemeParamsWithoutVotingMachineConfig =
+      scheme != null
+        ? R.filter(
+            param => param.typeName != "votingMachineConfig",
+            scheme.params
+          )
+        : []
+
+    if (scheme == null || schemeParamsWithoutVotingMachineConfig.length == 0) {
+      return null
+    } else {
+      return (
+        <Step key={"configureSchemeStep"}>
+          <StepLabel>Configure Scheme</StepLabel>
+          <StepContent>
+            {R.map(
+              param => (
+                <div key={`text-field-${param.typeName}`}>
+                  <TextField
+                    name={param.typeName}
+                    label={param.displayName}
+                    margin="normal"
+                    onChange={this.handleSchemeConfigParamsChange}
+                    value={R.pathOr("", [param.typeName], schemeConfig.params)}
+                    onBlur={() => console.log("TODO: validate fields")}
+                    fullWidth
+                    required={!R.pathOr(false, ["optional"], param)}
+                  />
+                  <Typography gutterBottom>
+                    <i>{param.description}</i>
+                  </Typography>
+                </div>
+              ),
+              schemeParamsWithoutVotingMachineConfig
+            )}
+            {this.stepControlls(false, isLastStep, true, classes)}
+          </StepContent>
+        </Step>
+      )
+    }
+  }
+  selectVotingMachineStep = (
+    votingMachineConfig: VotingMachineConfiguration,
+    classes: any
+  ) => {
+    const votingMachine = getVotingMachine(votingMachineConfig.typeName)
+    return (
+      <Step key={"selectVotingMachineStep"}>
+        <StepLabel>Select Voting Machine</StepLabel>
+        <StepContent>
+          <Typography className={classes.guidingText}>
+            What type of voting should be used for this scheme?
+          </Typography>
+          <FormControl className={classes.formControl}>
+            <InputLabel htmlFor="voting-machine">Voting Machine</InputLabel>
+            <Select
+              className={classes.select}
+              onChange={this.handleVotingMachineTypeChange}
+              value={votingMachine != null ? votingMachine.typeName : ""}
+              inputProps={{
+                name: "votingMachine",
+                id: "voting-machine",
+              }}
+            >
+              {R.map(votingMachine => {
+                return (
+                  <MenuItem
+                    key={`voting-machine-select-${votingMachine.typeName}`}
+                    value={votingMachine.typeName}
+                  >
+                    {votingMachine.displayName}
+                  </MenuItem>
+                )
+              }, R.values(votingMachines))}
+            </Select>
+          </FormControl>
+          {votingMachine != null ? (
+            <Typography className={classes.description}>
+              {votingMachine.description}
+            </Typography>
+          ) : null}
+          {this.stepControlls(false, false, votingMachine != null, classes)}
+        </StepContent>
+      </Step>
+    )
+  }
+  configureVotingMachineStep = (
+    votingMachineConfig: VotingMachineConfiguration,
+    classes: any
+  ) => {
+    const votingMachine = getVotingMachine(votingMachineConfig.typeName)
+    return (
+      <Step key={"configureVotingMachineStep"}>
+        <StepLabel>Configure Voting Machine</StepLabel>
+        <StepContent>
+          <Typography className={classes.guidingText}>
+            Specify Voting Machine parameters
+          </Typography>
+          {R.map(
+            param => (
+              <div key={`text-field-${param.typeName}`}>
+                <TextField
+                  name={param.typeName}
+                  label={param.displayName}
+                  margin="normal"
+                  onChange={this.handleVotingMachineParamsChange}
+                  value={
+                    votingMachineConfig != null
+                      ? R.prop(
+                          param.typeName,
+                          votingMachineConfig.params as any
+                        )
+                      : ""
+                  }
+                  onBlur={() => console.log("TODO: validate fields")}
+                  fullWidth
+                  required={!R.pathOr(false, ["optional"], param)}
+                />
+                <Typography gutterBottom>
+                  <i>{param.description}</i>
+                </Typography>
+              </div>
+            ),
+            votingMachine != null ? votingMachine.params : []
+          )}
+          {this.stepControlls(false, true, true, classes)}
+        </StepContent>
+      </Step>
+    )
+  }
+
   render() {
     const { classes, open } = this.props
     const { activeStep, schemeConfig } = this.state
     const { typeName: schemeTypeName, params: schemeParams } = schemeConfig
-    const { votingMachineConfig } = schemeParams
     const scheme = getScheme(schemeTypeName)
-    const votingMachine = getVotingMachine(votingMachineConfig.typeName)
+    const shouldHaveVotingMachine =
+      scheme != null
+        ? R.any(
+            param => param.typeName === "votingMachineConfig",
+            scheme.params
+          )
+        : null
+    const votingMachineConfig: VotingMachineConfiguration = schemeConfig.params
+      .votingMachineConfig || {
+      typeName: "",
+      params: [],
+    }
 
     return (
       <Dialog open={open}>
@@ -218,158 +402,23 @@ class VerticalLinearStepper extends React.Component<Props, State> {
           </DialogContentText>
           <div className={classes.root}>
             <Stepper activeStep={activeStep} orientation="vertical">
-              <Step>
-                <StepLabel>Select Scheme</StepLabel>
-                <StepContent>
-                  <FormControl className={classes.formControl}>
-                    <InputLabel htmlFor="scheme-select">Scheme</InputLabel>
-                    <Select
-                      className={classes.select}
-                      value={schemeTypeName}
-                      onChange={this.setSchemeType}
-                      inputProps={{
-                        name: "Scheme",
-                        id: "scheme-select",
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>None</em>
-                      </MenuItem>
-                      {R.map(
-                        scheme => (
-                          <MenuItem
-                            value={scheme.typeName}
-                            key={"select-item-" + scheme.typeName}
-                          >
-                            {scheme.displayName}
-                          </MenuItem>
-                        ),
-                        schemes
-                      )}
-                    </Select>
-                  </FormControl>
-                  {scheme != null ? (
-                    <Typography className={classes.description}>
-                      {scheme.description}
-                    </Typography>
-                  ) : null}
-                  {this.stepControlls(true, false, scheme != null, classes)}
-                </StepContent>
-              </Step>
-              {scheme != null && scheme.params.length > 0 ? (
-                <Step>
-                  <StepLabel>Configure Scheme</StepLabel>
-                  <StepContent>
-                    {R.map(
-                      param => (
-                        <div key={`text-field-${param.typeName}`}>
-                          <TextField
-                            name={param.typeName}
-                            label={param.displayName}
-                            margin="normal"
-                            onChange={this.handleSchemeConfigParamsChange}
-                            value={R.prop(param.typeName, schemeConfig.params)}
-                            onBlur={() => console.log("TODO: validate fields")}
-                            fullWidth
-                            required={!R.pathOr(false, ["optional"], param)}
-                          />
-                          <Typography gutterBottom>
-                            <i>{param.description}</i>
-                          </Typography>
-                        </div>
-                      ),
-                      scheme != null && scheme.params.length > 0
-                        ? scheme.params
-                        : []
-                    )}
-                    {this.stepControlls(true, false, scheme != null, classes)}
-                  </StepContent>
-                </Step>
-              ) : null}
-              <Step>
-                <StepLabel>Select Voting Machine</StepLabel>
-                <StepContent>
-                  <Typography className={classes.guidingText}>
-                    What type of voting should be used for this scheme?
-                  </Typography>
-                  <FormControl className={classes.formControl}>
-                    <InputLabel htmlFor="voting-machine">
-                      Voting Machine
-                    </InputLabel>
-                    <Select
-                      className={classes.select}
-                      onChange={this.handleVotingMachineTypeChange}
-                      value={
-                        votingMachine != null ? votingMachine.typeName : ""
-                      }
-                      inputProps={{
-                        name: "votingMachine",
-                        id: "voting-machine",
-                      }}
-                    >
-                      {R.map(votingMachine => {
-                        return (
-                          <MenuItem
-                            key={`voting-machine-select-${
-                              votingMachine.typeName
-                            }`}
-                            value={votingMachine.typeName}
-                          >
-                            {votingMachine.displayName}
-                          </MenuItem>
-                        )
-                      }, R.values(votingMachines))}
-                    </Select>
-                  </FormControl>
-                  {votingMachine != null ? (
-                    <Typography className={classes.description}>
-                      {votingMachine.description}
-                    </Typography>
-                  ) : null}
-                  {this.stepControlls(
-                    false,
-                    false,
-                    votingMachine != null,
-                    classes
-                  )}
-                </StepContent>
-              </Step>
-              <Step>
-                <StepLabel>Configure Voting Machine</StepLabel>
-                <StepContent>
-                  <Typography className={classes.guidingText}>
-                    Specify Voting Machine parameters
-                  </Typography>
-                  {R.map(
-                    param => (
-                      <div key={`text-field-${param.typeName}`}>
-                        <TextField
-                          name={param.typeName}
-                          label={param.displayName}
-                          margin="normal"
-                          onChange={this.handleVotingMachineParamsChange}
-                          value={
-                            votingMachineConfig != null
-                              ? R.prop(
-                                  param.typeName,
-                                  votingMachineConfig.params as any
-                                )
-                              : ""
-                          }
-                          onBlur={() => console.log("TODO: validate fields")}
-                          fullWidth
-                          required={!R.pathOr(false, ["optional"], param)}
-                        />
-                        <Typography gutterBottom>
-                          <i>{param.description}</i>
-                        </Typography>
-                      </div>
+              {this.selectSchemeStep(scheme, classes)}
+              {this.configureSchemeStep(
+                scheme,
+                schemeConfig,
+                !shouldHaveVotingMachine,
+                classes
+              )}
+
+              {scheme != null && shouldHaveVotingMachine
+                ? [
+                    this.selectVotingMachineStep(votingMachineConfig, classes),
+                    this.configureVotingMachineStep(
+                      votingMachineConfig,
+                      classes
                     ),
-                    votingMachine != null ? votingMachine.params : []
-                  )}
-                  {this.stepControlls(false, true, true, classes)}
-                </StepContent>
-              </Step>
+                  ]
+                : null}
             </Stepper>
           </div>
         </DialogContent>

--- a/src/components/pages/DAOcreator/SchemesStep/index.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/index.tsx
@@ -83,9 +83,11 @@ class SchemesStep extends React.Component<Props, State> {
                     </Typography>
                   </div>
                   <div className={classes.column}>
-                    <Typography className={classes.secondaryHeading}>
-                      {schemeConfig.params.votingMachineConfig.typeName}
-                    </Typography>
+                    {schemeConfig.params.votingMachineConfig != null ? (
+                      <Typography className={classes.secondaryHeading}>
+                        {schemeConfig.params.votingMachineConfig.typeName}
+                      </Typography>
+                    ) : null}
                   </div>
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>

--- a/src/lib/integrations/daoStack/arc/createDao.ts
+++ b/src/lib/integrations/daoStack/arc/createDao.ts
@@ -79,6 +79,15 @@ export const createDao = async (
   console.log("Created new organization.")
   console.log(tx)
 
+  const avatar = new web3.eth.Contract(
+    require("@daostack/arc/build/contracts/Avatar.json").abi,
+    Avatar,
+    opts
+  )
+
+  const daoToken = await avatar.methods.nativeToken().call()
+  const reputation = await avatar.methods.nativeReputation().call()
+
   const votingMachineConfigToHash = (
     votingMachineConfig: VotingMachineConfiguration
   ) => {
@@ -200,6 +209,8 @@ export const createDao = async (
     R.map(async ({ schemeConfig, schemeContract, votingMachineHash }) => {
       let deploymentInfo = {
         avatar: Avatar,
+        daoToken,
+        reputation,
       }
 
       if (votingMachineHash != null) {
@@ -213,6 +224,7 @@ export const createDao = async (
           votingMachineParametersKey,
         })
       }
+      console.log(deploymentInfo)
       const setParams = schemeContract.methods.setParameters.apply(
         null,
         getSchemeCallableParamsArray(schemeConfig, deploymentInfo)
@@ -247,15 +259,6 @@ export const createDao = async (
     .send()
   console.log("DAO schemes set.")
   console.log(tx)
-
-  const avatar = new web3.eth.Contract(
-    require("@daostack/arc/build/contracts/Avatar.json").abi,
-    Avatar,
-    opts
-  )
-
-  const daoToken = await avatar.methods.nativeToken().call()
-  const reputation = await avatar.methods.nativeReputation().call()
 
   return {
     avatar: Avatar,

--- a/src/lib/integrations/daoStack/arc/createDao.ts
+++ b/src/lib/integrations/daoStack/arc/createDao.ts
@@ -201,11 +201,10 @@ export const createDao = async (
 
       const setParams = schemeContract.methods.setParameters.apply(
         null,
-        getSchemeCallableParamsArray(
-          schemeConfig,
+        getSchemeCallableParamsArray(schemeConfig, {
           votingMachineAddress,
-          votingMachineParametersKey
-        )
+          votingMachineParametersKey,
+        })
       )
       const schemeParametersKey = await setParams.call()
 

--- a/src/lib/integrations/daoStack/arc/index.ts
+++ b/src/lib/integrations/daoStack/arc/index.ts
@@ -67,10 +67,6 @@ export const initSchemeConfig = (
   typeName: string = "",
   params: any = {}
 ): SchemeConfig => {
-  params["votingMachineConfig"] = R.propOr<VotingMachineConfiguration>(
-    { typeName: "", params: {} },
-    "votingMachineConfig"
-  )(params)
   return {
     id,
     typeName,

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -107,7 +107,30 @@ export const schemes: Scheme[] = [
       "Makes it possible for the DAO to open a registry. Other DAOs can then add and promote themselves on this registry.",
     toggleDefault: false,
     permissions: "0x00000000" /* no permissions */,
-    params: [],
+    params: [
+      {
+        typeName: "token",
+        valueType: "Address",
+        displayName: "Pay Token",
+        description:
+          "The ERC20 token to pay for register or promotion, an address.",
+        defaultValue: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359", // DAI. TODO: make this show up nicely in th UI
+      },
+      {
+        typeName: "fee",
+        valueType: "number",
+        displayName: "Registration Fee",
+        description: "Fee for adding something to the register in Wei",
+        defaultValue: 100,
+      },
+      {
+        typeName: "beneficiary",
+        valueType: "Address",
+        displayName: "Beneficiary",
+        description: "The beneficiary payment address",
+        defaultValue: "", // TODO: can we know the DAO's avatar address in advance (CREATE2) in order to set this to the avatar here (before the DAO is created)? Or should we set up the DAO ("forgeOrg") before we start defining schemes? We allready have all the needed information to forg the org.
+      },
+    ],
     getCallableParamsArray: function(
       schemeConfig,
       votingMachineAddress,

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -1,4 +1,4 @@
-import { Scheme, SchemeConfig } from "./types"
+import { Scheme, SchemeConfig, DeploymentInfo } from "./types"
 import * as R from "ramda"
 import Web3 from "web3"
 
@@ -140,7 +140,7 @@ export const schemes: Scheme[] = [
         valueType: "Address",
         displayName: "Beneficiary",
         description: "The beneficiary payment address",
-        defaultValue: "", // TODO: can we know the DAO's avatar address in advance (CREATE2) in order to set this to the avatar here (before the DAO is created)? Or should we set up the DAO ("forgeOrg") before we start defining schemes? We allready have all the needed information to forg the org.
+        defaultValue: "",
       },
     ],
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
@@ -227,7 +227,7 @@ export const getScheme = (typeName: string) =>
 
 export const getSchemeCallableParamsArray = (
   schemeConfig: SchemeConfig,
-  deploymentInfo: any = {}
+  deploymentInfo: DeploymentInfo
 ) =>
   getScheme(schemeConfig.typeName).getCallableParamsArray(
     schemeConfig,

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -10,7 +10,6 @@ export const schemes: Scheme[] = [
       "Contributors can propose rewards for themselves and others. These rewards can be tokens, reputation, or a combination.",
     toggleDefault: true,
     permissions: "0x00000000" /* no permissions */,
-    // TODO: add parameters (orgNativeTokenFeeGWei)
     params: [
       {
         typeName: "orgNativeTokenFeeGWei",
@@ -19,12 +18,18 @@ export const schemes: Scheme[] = [
         description: "Fee in GWei:",
         defaultValue: 0,
       },
+      {
+        typeName: "votingMachineConfig",
+        valueType: "VotingMachineConfig",
+        displayName: "Voting Machine Configuration",
+        description: "VotingMachine",
+      },
     ],
-    getCallableParamsArray: function(
-      schemeConfig,
-      votingMachineAddress,
-      votingMachineParametersKey
-    ) {
+    getCallableParamsArray: function(schemeConfig, deploymentInfo) {
+      const {
+        votingMachineParametersKey,
+        votingMachineAddress,
+      } = deploymentInfo
       return [
         Web3.utils.toWei(
           schemeConfig.params.orgNativeTokenFeeGWei.toString(),
@@ -42,12 +47,19 @@ export const schemes: Scheme[] = [
       "Proposals that, when passed, invoke a vote within another DAO.",
     toggleDefault: true,
     permissions: "0x00000000" /* no permissions */,
-    params: [],
-    getCallableParamsArray: function(
-      schemeConfig,
-      votingMachineAddress,
-      votingMachineParametersKey
-    ) {
+    params: [
+      {
+        typeName: "votingMachineConfig",
+        valueType: "VotingMachineConfig",
+        displayName: "Voting Machine Configuration",
+        description: "VotingMachine",
+      },
+    ],
+    getCallableParamsArray: function(schemeConfig, deploymentInfo) {
+      const {
+        votingMachineParametersKey,
+        votingMachineAddress,
+      } = deploymentInfo
       return [votingMachineParametersKey, votingMachineAddress]
     },
   },
@@ -131,12 +143,9 @@ export const schemes: Scheme[] = [
         defaultValue: "", // TODO: can we know the DAO's avatar address in advance (CREATE2) in order to set this to the avatar here (before the DAO is created)? Or should we set up the DAO ("forgeOrg") before we start defining schemes? We allready have all the needed information to forg the org.
       },
     ],
-    getCallableParamsArray: function(
-      schemeConfig,
-      votingMachineAddress,
-      votingMachineParametersKey
-    ) {
-      return [] // TODO
+    getCallableParamsArray: function(schemeConfig, deploymentInfo) {
+      const { token, fee, beneficiary } = schemeConfig.params
+      return [token, fee, beneficiary] // TODO
     },
   },
   {
@@ -145,12 +154,19 @@ export const schemes: Scheme[] = [
     description: "Enables the DAO to upgrade itself.",
     toggleDefault: true,
     permissions: "0x0000000A" /* manage schemes + upgrade controller */,
-    params: [],
-    getCallableParamsArray: function(
-      schemeConfig,
-      votingMachineAddress,
-      votingMachineParametersKey
-    ) {
+    params: [
+      {
+        typeName: "votingMachineConfig",
+        valueType: "VotingMachineConfig",
+        displayName: "Voting Machine Configuration",
+        description: "VotingMachine",
+      },
+    ],
+    getCallableParamsArray: function(schemeConfig, deploymentInfo) {
+      const {
+        votingMachineParametersKey,
+        votingMachineAddress,
+      } = deploymentInfo
       return [votingMachineParametersKey, votingMachineAddress]
     },
   },
@@ -161,12 +177,19 @@ export const schemes: Scheme[] = [
       "Manages post-creation adding/modifying and removing of features. Features add functionality to the DAO.",
     toggleDefault: true,
     permissions: "0x0000001F" /* all permissions */,
-    params: [],
-    getCallableParamsArray: function(
-      schemeConfig,
-      votingMachineAddress,
-      votingMachineParametersKey
-    ) {
+    params: [
+      {
+        typeName: "votingMachineConfig",
+        valueType: "VotingMachineConfig",
+        displayName: "Voting Machine Configuration",
+        description: "VotingMachine",
+      },
+    ],
+    getCallableParamsArray: function(schemeConfig, deploymentInfo) {
+      const {
+        votingMachineParametersKey,
+        votingMachineAddress,
+      } = deploymentInfo
       return [
         votingMachineParametersKey,
         votingMachineParametersKey,
@@ -181,12 +204,19 @@ export const schemes: Scheme[] = [
       'Makes it possible to add/modify and remove constraints for the DAO. A constraint defines what "cannot be done" in the DAO. For instance, limit the number of tokens that a DAO can create.',
     toggleDefault: true,
     permissions: "0x00000004" /* manage global constraints */,
-    params: [],
-    getCallableParamsArray: function(
-      schemeConfig,
-      votingMachineAddress,
-      votingMachineParametersKey
-    ) {
+    params: [
+      {
+        typeName: "votingMachineConfig",
+        valueType: "VotingMachineConfig",
+        displayName: "Voting Machine Configuration",
+        description: "VotingMachine",
+      },
+    ],
+    getCallableParamsArray: function(schemeConfig, deploymentInfo) {
+      const {
+        votingMachineParametersKey,
+        votingMachineAddress,
+      } = deploymentInfo
       return [votingMachineParametersKey, votingMachineAddress]
     },
   },
@@ -197,11 +227,9 @@ export const getScheme = (typeName: string) =>
 
 export const getSchemeCallableParamsArray = (
   schemeConfig: SchemeConfig,
-  votingMachineAddress: string,
-  votingMachineParametersKey: string
+  deploymentInfo: any = {}
 ) =>
   getScheme(schemeConfig.typeName).getCallableParamsArray(
     schemeConfig,
-    votingMachineAddress,
-    votingMachineParametersKey
+    deploymentInfo
   )

--- a/src/lib/integrations/daoStack/arc/types.ts
+++ b/src/lib/integrations/daoStack/arc/types.ts
@@ -46,7 +46,9 @@ export type Founder = {
 export type SchemeConfig = {
   id: string
   typeName: string // not schemeTypeName (that is in use now)
-  params: ParamConfig & { votingMachineConfig: VotingMachineConfiguration }
+  params: ParamConfig & {
+    votingMachineConfig: VotingMachineConfiguration | null
+  }
 }
 
 export type Scheme = {
@@ -70,4 +72,12 @@ export type DAO = {
   name: string
   daoToken: string
   reputation: string
+}
+
+export type DeploymentInfo = {
+  avatar: string // address
+  daoToken?: string // address
+  reputation?: string // address
+  votingMachineParametersKey?: string // hash
+  votingMachineAddress?: string // address
 }

--- a/src/lib/integrations/daoStack/arc/types.ts
+++ b/src/lib/integrations/daoStack/arc/types.ts
@@ -24,10 +24,16 @@ export type VotingMachine = {
 
 export type Param = {
   typeName: string
-  valueType: "boolean" | "string" | "number" | "Address" | "BigNumber"
+  valueType:
+    | "boolean"
+    | "string"
+    | "number"
+    | "Address"
+    | "BigNumber"
+    | "VotingMachineConfig"
   displayName: string
   description: string
-  defaultValue: string | number | boolean
+  defaultValue?: string | number | boolean
   optional?: boolean
 }
 
@@ -52,8 +58,7 @@ export type Scheme = {
   permissions: string
   getCallableParamsArray: (
     schemeConfig: SchemeConfig,
-    votingMachineAddress: string,
-    votingMachineParametersKey: string
+    deploymentInfo: any
   ) => any[]
   params: Param[]
 }

--- a/src/lib/integrations/daoStack/arc/types.ts
+++ b/src/lib/integrations/daoStack/arc/types.ts
@@ -60,7 +60,7 @@ export type Scheme = {
   permissions: string
   getCallableParamsArray: (
     schemeConfig: SchemeConfig,
-    deploymentInfo: any
+    deploymentInfo: DeploymentInfo
   ) => any[]
   params: Param[]
 }

--- a/src/lib/integrations/daoStack/arc/types.ts
+++ b/src/lib/integrations/daoStack/arc/types.ts
@@ -76,8 +76,8 @@ export type DAO = {
 
 export type DeploymentInfo = {
   avatar: string // address
-  daoToken?: string // address
-  reputation?: string // address
+  daoToken: string // address
+  reputation: string // address
   votingMachineParametersKey?: string // hash
   votingMachineAddress?: string // address
 }


### PR DESCRIPTION
Closes #92 
and
- Make it possible to add schemes that do not use a voting machine.
- Make daoToken and reputation addresses available to the `getCallableParamsArray` function through the DeploymentInfo object.

