### PR TITLE
validate scheme inputs

### DIFF
--- a/src/components/pages/DAOcreator/LiveDao.tsx
+++ b/src/components/pages/DAOcreator/LiveDao.tsx
@@ -12,7 +12,11 @@ import * as React from "react"
 import { connect } from "react-redux"
 import { Dispatch } from "redux"
 import { RootState } from "../../../state"
-import { Founder, Scheme, DAO } from "../../../lib/integrations/daoStack/arc"
+import {
+  Founder,
+  SchemeDefinition,
+  DAO,
+} from "../../../lib/integrations/daoStack/arc"
 
 interface Props extends WithStyles<typeof styles> {
   dao: DAO | undefined
@@ -96,7 +100,11 @@ const displayFounder = ({ address, reputation, tokens }: Founder) => (
   </Grid>
 )
 
-const displayScheme = ({ displayName, description, typeName }: Scheme) => (
+const displayScheme = ({
+  displayName,
+  description,
+  typeName,
+}: SchemeDefinition) => (
   <Grid container spacing={16} key={`founder-${typeName}`}>
     <Grid item xs={12}>
       <Typography variant="subtitle1">{displayName}</Typography>

--- a/src/components/pages/DAOcreator/ReviewStep.tsx
+++ b/src/components/pages/DAOcreator/ReviewStep.tsx
@@ -14,10 +14,10 @@ import { connect } from "react-redux"
 import { Dispatch } from "redux"
 import {
   Founder,
-  Scheme,
-  VotingMachine,
+  SchemeDefinition,
+  VotingMachineDefinition,
   votingMachines,
-  VotingMachineConfiguration,
+  VotingMachineConfig,
   SchemeConfig,
   getScheme,
 } from "../../../lib/integrations/daoStack/arc"

--- a/src/components/pages/DAOcreator/ReviewStep.tsx
+++ b/src/components/pages/DAOcreator/ReviewStep.tsx
@@ -16,7 +16,7 @@ import {
   Founder,
   SchemeDefinition,
   VotingMachineDefinition,
-  votingMachines,
+  votingMachineDefinitions,
   VotingMachineConfig,
   SchemeConfig,
   getSchemeDefinition,
@@ -176,16 +176,18 @@ const displayFounder = ({ address, reputation, tokens }: Founder) => (
 
 const displayScheme = (schemeConfig: SchemeConfig) => {
   const votingMachine =
-    votingMachines[
+    votingMachineDefinitions[
       R.pathOr(null, ["votingMachineConfig", "typeName"], schemeConfig.params)
     ]
-  const scheme = getSchemeDefinition(schemeConfig.typeName)
+  const schemeDefinition = getSchemeDefinition(schemeConfig.typeName)
   return (
-    <Grid container spacing={16} key={`scheme-${scheme.typeName}`}>
+    <Grid container spacing={16} key={`scheme-${schemeDefinition.typeName}`}>
       <Grid item xs={12}>
-        <Typography variant="subtitle1">{scheme.displayName}</Typography>
+        <Typography variant="subtitle1">
+          {schemeDefinition.displayName}
+        </Typography>
         <Typography>
-          <i>{scheme.description}</i>
+          <i>{schemeDefinition.description}</i>
         </Typography>
       </Grid>
       {votingMachine != null ? (

--- a/src/components/pages/DAOcreator/ReviewStep.tsx
+++ b/src/components/pages/DAOcreator/ReviewStep.tsx
@@ -19,7 +19,7 @@ import {
   votingMachines,
   VotingMachineConfig,
   SchemeConfig,
-  getScheme,
+  getSchemeDefinition,
 } from "../../../lib/integrations/daoStack/arc"
 import PieChart from "../../common/PieChart"
 import EthAddressAvatar from "../../common/EthAddressAvatar"
@@ -179,7 +179,7 @@ const displayScheme = (schemeConfig: SchemeConfig) => {
     votingMachines[
       R.pathOr(null, ["votingMachineConfig", "typeName"], schemeConfig.params)
     ]
-  const scheme = getScheme(schemeConfig.typeName)
+  const scheme = getSchemeDefinition(schemeConfig.typeName)
   return (
     <Grid container spacing={16} key={`scheme-${scheme.typeName}`}>
       <Grid item xs={12}>

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -107,15 +107,12 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     let errorMessage = ""
 
     switch (valueType) {
-      case "address": {
+      case "Address": {
         errorMessage = FormValidation.isValidAddress(value)
         break
       }
       case "number": {
         errorMessage = FormValidation.isBigNumber(value)
-        break
-      }
-      default: {
         break
       }
     }
@@ -126,7 +123,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
         typeName,
         params: R.assoc(paramName, value, params),
       },
-      formErrors: R.assoc(paramName, errorMessage, this.state.formErrors),
+      formErrors: { [paramName]: errorMessage },
     })
 
     const formIsValid = R.none(
@@ -303,6 +300,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
                   <TextField
                     name={param.typeName}
                     label={param.displayName}
+                    error={!R.isEmpty(this.state.formErrors[param.typeName])}
                     margin="normal"
                     onChange={e =>
                       this.handleSchemeConfigParamsChange(e, param.valueType)
@@ -323,7 +321,12 @@ class VerticalLinearStepper extends React.Component<Props, State> {
               ),
               schemeParamsWithoutVotingMachineConfig
             )}
-            {this.stepControls(false, isLastStep, true, classes)}
+            {this.stepControls(
+              false,
+              isLastStep,
+              this.state.formIsValid,
+              classes
+            )}
           </StepContent>
         </Step>
       )

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -360,7 +360,10 @@ class VerticalLinearStepper extends React.Component<Props, State> {
                   <TextField
                     name={param.typeName}
                     label={param.displayName}
-                    error={!R.isEmpty(this.state.formErrors[param.typeName])}
+                    error={
+                      R.has(param.typeName, this.state.formErrors) &&
+                      !R.isEmpty(this.state.formErrors[param.typeName])
+                    }
                     margin="normal"
                     onChange={this.handleSchemeConfigParamsChange(param)}
                     value={R.prop(param.typeName, schemeConfig.params)}
@@ -449,7 +452,10 @@ class VerticalLinearStepper extends React.Component<Props, State> {
                   name={param.typeName}
                   label={param.displayName}
                   margin="normal"
-                  error={!R.isEmpty(this.state.formErrors[param.typeName])}
+                  error={
+                    R.has(param.typeName, this.state.formErrors) &&
+                    !R.isEmpty(this.state.formErrors[param.typeName])
+                  }
                   onChange={this.handleVotingMachineParamsChange(param)}
                   value={
                     votingMachineConfig != null

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -504,14 +504,16 @@ class VerticalLinearStepper extends React.Component<Props, State> {
           <div className={classes.root}>
             <Stepper activeStep={activeStep} orientation="vertical">
               {this.selectSchemeStep(scheme, classes)}
-              {this.configureSchemeStep(
-                scheme,
-                schemeConfig,
-                !hasVotingMachine,
-                classes
-              )}
+              {scheme != null && scheme.params.length > 0
+                ? this.configureSchemeStep(
+                    scheme,
+                    schemeConfig,
+                    !hasVotingMachine,
+                    classes
+                  )
+                : null}
 
-              {scheme != null
+              {scheme != null && hasVotingMachine
                 ? [
                     this.selectVotingMachineStep(
                       votingMachineConfig as VotingMachineConfig,

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -97,7 +97,8 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     const { params: paramValues } = schemeConfig
     const formErrorObject = FormValidation.generateFormErrors(
       paramTypes,
-      paramValues
+      paramValues,
+      this.state.formErrors
     )
     // check if the form is valide
     const formIsValid = R.none(
@@ -118,7 +119,8 @@ class VerticalLinearStepper extends React.Component<Props, State> {
       const { params: paramValues } = config
       const formErrorObject = FormValidation.generateFormErrors(
         paramTypes,
-        paramValues
+        paramValues,
+        this.state.formErrors
       )
 
       // check if the form is valide
@@ -207,6 +209,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
   ) => async (event: any) => {
     const { value } = event.target
     const oldVotingMachineConfig = this.state.schemeConfig.votingMachineConfig
+    await this.validateParam(paramDefinition, value)
     const newVotingMachineConfig =
       oldVotingMachineConfig != null
         ? {

--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -25,14 +25,14 @@ import * as React from "react"
 import {
   getSchemeDefinition,
   getSchemeDefaultParams,
-  getVotingMachine,
+  getVotingMachineDefinition,
   getVotingMachineDefaultParams,
-  schemes,
+  schemeDefinitions,
   SchemeDefinition,
   SchemeConfig,
   ParamDefinition,
   VotingMachineConfig,
-  votingMachines,
+  votingMachineDefinitions,
   initSchemeConfig,
 } from "../../../../lib/integrations/daoStack/arc"
 import * as FormValidation from "../../../../lib/formValidation"
@@ -116,7 +116,9 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     votingMachineConfig: VotingMachineConfig | undefined
   ) => {
     if (votingMachineConfig) {
-      const votingMachine = getVotingMachine(votingMachineConfig.typeName)
+      const votingMachine = getVotingMachineDefinition(
+        votingMachineConfig.typeName
+      )
       const { params: paramTypes } = votingMachine
       const { params: paramValues } = votingMachineConfig
       const formErrorObject = FormValidation.generateFormErrors(
@@ -334,7 +336,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
                   {scheme.displayName}
                 </MenuItem>
               ),
-              schemes
+              schemeDefinitions
             )}
           </Select>
         </FormControl>
@@ -400,7 +402,9 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     votingMachineConfig: VotingMachineConfig,
     classes: any
   ) => {
-    const votingMachine = getVotingMachine(votingMachineConfig.typeName)
+    const votingMachine = getVotingMachineDefinition(
+      votingMachineConfig.typeName
+    )
     return (
       <Step key={"selectVotingMachineStep"}>
         <StepLabel>Select Voting Machine</StepLabel>
@@ -428,7 +432,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
                     {votingMachine.displayName}
                   </MenuItem>
                 )
-              }, R.values(votingMachines))}
+              }, R.values(votingMachineDefinitions))}
             </Select>
           </FormControl>
           {votingMachine != null ? (
@@ -445,7 +449,9 @@ class VerticalLinearStepper extends React.Component<Props, State> {
     votingMachineConfig: VotingMachineConfig,
     classes: any
   ) => {
-    const votingMachine = getVotingMachine(votingMachineConfig.typeName)
+    const votingMachine = getVotingMachineDefinition(
+      votingMachineConfig.typeName
+    )
     return (
       <Step key={"configureVotingMachineStep"}>
         <StepLabel>Configure Voting Machine</StepLabel>
@@ -498,7 +504,6 @@ class VerticalLinearStepper extends React.Component<Props, State> {
       typeName: "",
       params: [],
     }
-    console.log(schemeDefinition)
     const hasVotingMachine =
       schemeDefinition != null ? schemeDefinition.hasVotingMachine : false
 

--- a/src/components/pages/DAOcreator/SchemesStep/index.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/index.tsx
@@ -19,7 +19,7 @@ import * as React from "react"
 import { connect } from "react-redux"
 import { bindActionCreators, Dispatch } from "redux"
 import {
-  getScheme,
+  getSchemeDefinition,
   SchemeConfig,
   VotingMachineConfig,
 } from "../../../../lib/integrations/daoStack/arc"
@@ -69,7 +69,7 @@ class SchemesStep extends React.Component<Props, State> {
       <Card className={classes.card}>
         <div className={classes.root}>
           {R.map(schemeConfig => {
-            const scheme = getScheme(schemeConfig.typeName)
+            const scheme = getSchemeDefinition(schemeConfig.typeName)
             return (
               <ExpansionPanel
                 expanded={expanded === schemeConfig.id}

--- a/src/components/pages/DAOcreator/SchemesStep/index.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/index.tsx
@@ -21,7 +21,7 @@ import { bindActionCreators, Dispatch } from "redux"
 import {
   getScheme,
   SchemeConfig,
-  VotingMachineConfiguration,
+  VotingMachineConfig,
 } from "../../../../lib/integrations/daoStack/arc"
 import DAOcreatorActions, * as daoCreatorActions from "../../../../redux/actions/daoCreator"
 import AddSchemeDialog from "./AddSchemeDialog"
@@ -83,9 +83,9 @@ class SchemesStep extends React.Component<Props, State> {
                     </Typography>
                   </div>
                   <div className={classes.column}>
-                    {schemeConfig.params.votingMachineConfig != null ? (
+                    {schemeConfig.votingMachineConfig != null ? (
                       <Typography className={classes.secondaryHeading}>
-                        {schemeConfig.params.votingMachineConfig.typeName}
+                        {schemeConfig.votingMachineConfig.typeName}
                       </Typography>
                     ) : null}
                   </div>

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -35,9 +35,9 @@ export const isBigNumber = checkIfHasError(
 
 export const generateFormErrors = (
   paramTypes: ParamDefinition[],
-  paramValues: ParamConfig
+  paramValues: ParamConfig,
+  formErrors: any
 ) => {
-  let formErrors = {}
   const formErrorObject = R.reduce(
     (acc, paramType) => {
       const value = paramValues[paramType.typeName]

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -34,7 +34,7 @@ export const isBigNumber = checkIfHasError(
 )
 
 export const generateFormErrors = (
-  paramTypes: ParamDefinition[],
+  paramDefinitions: ParamDefinition[],
   paramValues: ParamConfig,
   formErrors: any
 ) => {
@@ -48,7 +48,7 @@ export const generateFormErrors = (
       return { ...acc, [paramType.typeName]: errorMessage }
     },
     formErrors,
-    paramTypes
+    paramDefinitions
   )
 
   return formErrors

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -1,5 +1,6 @@
 import { TypeValidation } from "./integrations/web3"
 import * as R from "ramda"
+import { ParamConfig, ParamDefinition } from "./integrations/daoStack/arc"
 
 export function checkIfHasError<ValueType>(
   predicate: (value: ValueType) => boolean,
@@ -8,13 +9,13 @@ export function checkIfHasError<ValueType>(
   return (value: ValueType) => (predicate(value) ? errorMessage : "")
 }
 
-const nameHasError = (name: string) =>
+const nameHasError = (name: any) =>
   R.isEmpty(name) || name.length > 70 || /[_\W\d]/.test(name)
 
-const addressHasError = (addr: string) =>
+const addressHasError = (addr: any) =>
   R.isEmpty(addr) || !TypeValidation.isAddress(addr)
 
-const numberHasError = (number: string) =>
+const numberHasError = (number: any) =>
   R.isEmpty(number) || !TypeValidation.isBigNumber(number)
 
 export const isValidName = checkIfHasError(
@@ -31,3 +32,24 @@ export const isBigNumber = checkIfHasError(
   numberHasError,
   "Please enter a valid number."
 )
+
+export const generateFormErrors = (
+  paramTypes: ParamDefinition[],
+  paramValues: ParamConfig
+) => {
+  let formErrors = {}
+  const formErrorObject = R.reduce(
+    (acc, paramType) => {
+      const value = paramValues[paramType.typeName]
+      let errorMessage = ""
+      if (value == null && !paramType.optional) {
+        errorMessage = "Required"
+      }
+      return { ...acc, [paramType.typeName]: errorMessage }
+    },
+    formErrors,
+    paramTypes
+  )
+
+  return formErrors
+}

--- a/src/lib/integrations/daoStack/arc/createDao.ts
+++ b/src/lib/integrations/daoStack/arc/createDao.ts
@@ -7,7 +7,7 @@ import {
 } from "./types"
 import { votingMachines, getVotingMachine } from "./votingMachines"
 import {
-  getScheme,
+  getSchemeDefinition,
   getSchemeCallableParamsArray,
   getVotingMachineCallableParamsArray,
 } from "./index"
@@ -189,7 +189,8 @@ export const createDao = async (
     initializedSchemes
   )
   const schemePermissions = R.map(
-    ({ schemeConfig }) => getScheme(schemeConfig.typeName).permissions,
+    ({ schemeConfig }) =>
+      getSchemeDefinition(schemeConfig.typeName).permissions,
     initializedSchemes
   )
 

--- a/src/lib/integrations/daoStack/arc/createDao.ts
+++ b/src/lib/integrations/daoStack/arc/createDao.ts
@@ -1,9 +1,9 @@
 import {
   DAO,
   Founder,
-  Scheme,
+  SchemeDefinition,
   SchemeConfig,
-  VotingMachineConfiguration,
+  VotingMachineConfig,
 } from "./types"
 import { votingMachines, getVotingMachine } from "./votingMachines"
 import {
@@ -89,7 +89,7 @@ export const createDao = async (
   const reputation = await avatar.methods.nativeReputation().call()
 
   const votingMachineConfigToHash = (
-    votingMachineConfig: VotingMachineConfiguration
+    votingMachineConfig: VotingMachineConfig
   ) => {
     const callableVotingParams = getVotingMachineCallableParamsArray(
       votingMachineConfig
@@ -108,16 +108,16 @@ export const createDao = async (
         opts
       ),
       votingMachineHash:
-        schemeConfig.params.votingMachineConfig != null
-          ? votingMachineConfigToHash(schemeConfig.params.votingMachineConfig)
+        schemeConfig.votingMachineConfig != null
+          ? votingMachineConfigToHash(schemeConfig.votingMachineConfig)
           : null,
     }
   }, schemesIn)
 
   const initializedVotingMachines: any = R.reduce(
     (acc, schemeConfig) => {
-      if (schemeConfig.params.votingMachineConfig != null) {
-        const votingMachineConfig = schemeConfig.params.votingMachineConfig
+      if (schemeConfig.votingMachineConfig != null) {
+        const votingMachineConfig = schemeConfig.votingMachineConfig
         const votingMachineContract = new web3.eth.Contract(
           require(`@daostack/arc/build/contracts/${
             votingMachineConfig.typeName

--- a/src/lib/integrations/daoStack/arc/createDao.ts
+++ b/src/lib/integrations/daoStack/arc/createDao.ts
@@ -5,7 +5,10 @@ import {
   SchemeConfig,
   VotingMachineConfig,
 } from "./types"
-import { votingMachines, getVotingMachine } from "./votingMachines"
+import {
+  votingMachineDefinitions,
+  getVotingMachineDefinition,
+} from "./votingMachines"
 import {
   getSchemeDefinition,
   getSchemeCallableParamsArray,

--- a/src/lib/integrations/daoStack/arc/index.ts
+++ b/src/lib/integrations/daoStack/arc/index.ts
@@ -13,9 +13,9 @@ import { createDao as createTheDao } from "./createDao"
 import {
   DAO,
   Founder,
-  Scheme,
-  VotingMachine,
-  VotingMachineConfiguration,
+  SchemeDefinition,
+  VotingMachineDefinition,
+  VotingMachineConfig,
   SchemeConfig,
 } from "./types"
 

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -207,20 +207,20 @@ export const schemes: SchemeDefinition[] = [
   },
 ]
 
-export const getScheme = (typeName: string) =>
+export const getSchemeDefinition = (typeName: string) =>
   R.find(scheme => scheme.typeName === typeName, schemes) as SchemeDefinition
 
 export const getSchemeCallableParamsArray = (
   schemeConfig: SchemeConfig,
   deploymentInfo: DeploymentInfo
 ) =>
-  getScheme(schemeConfig.typeName).getCallableParamsArray(
+  getSchemeDefinition(schemeConfig.typeName).getCallableParamsArray(
     schemeConfig,
     deploymentInfo
   )
 
 export const getSchemeDefaultParams = (typeName: string): any => {
-  const scheme = getScheme(typeName)
+  const scheme = getSchemeDefinition(typeName)
 
   return R.reduce(
     (acc, param) => R.assoc(param.typeName, param.defaultValue, acc),

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -2,7 +2,7 @@ import { SchemeDefinition, SchemeConfig, DeploymentInfo } from "./types"
 import * as R from "ramda"
 import Web3 from "web3"
 
-export const schemes: SchemeDefinition[] = [
+export const schemeDefinitions: SchemeDefinition[] = [
   {
     typeName: "GenericScheme",
     displayName: "Generic Scheme",
@@ -208,7 +208,10 @@ export const schemes: SchemeDefinition[] = [
 ]
 
 export const getSchemeDefinition = (typeName: string) =>
-  R.find(scheme => scheme.typeName === typeName, schemes) as SchemeDefinition
+  R.find(
+    scheme => scheme.typeName === typeName,
+    schemeDefinitions
+  ) as SchemeDefinition
 
 export const getSchemeCallableParamsArray = (
   schemeConfig: SchemeConfig,

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -1,8 +1,8 @@
-import { Scheme, SchemeConfig, DeploymentInfo } from "./types"
+import { SchemeDefinition, SchemeConfig, DeploymentInfo } from "./types"
 import * as R from "ramda"
 import Web3 from "web3"
 
-export const schemes: Scheme[] = [
+export const schemes: SchemeDefinition[] = [
   {
     typeName: "GenericScheme",
     displayName: "Generic Scheme",
@@ -17,13 +17,8 @@ export const schemes: Scheme[] = [
         displayName: "Contract Address",
         description: "Address of the contract to call",
       },
-      {
-        typeName: "votingMachineConfig",
-        valueType: "VotingMachineConfig",
-        displayName: "Voting Machine Configuration",
-        description: "VotingMachine",
-      },
     ],
+    hasVotingMachine: true,
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const {
         votingMachineParametersKey,
@@ -51,13 +46,8 @@ export const schemes: Scheme[] = [
         description: "Fee in GWei:",
         defaultValue: 0,
       },
-      {
-        typeName: "votingMachineConfig",
-        valueType: "VotingMachineConfig",
-        displayName: "Voting Machine Configuration",
-        description: "VotingMachine",
-      },
     ],
+    hasVotingMachine: true,
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const {
         votingMachineParametersKey,
@@ -80,14 +70,8 @@ export const schemes: Scheme[] = [
       "Proposals that, when passed, invoke a vote within another DAO.",
     toggleDefault: true,
     permissions: "0x00000000" /* no permissions */,
-    params: [
-      {
-        typeName: "votingMachineConfig",
-        valueType: "VotingMachineConfig",
-        displayName: "Voting Machine Configuration",
-        description: "VotingMachine",
-      },
-    ],
+    params: [],
+    hasVotingMachine: true,
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const {
         votingMachineParametersKey,
@@ -161,6 +145,7 @@ export const schemes: Scheme[] = [
         defaultValue: "",
       },
     ],
+    hasVotingMachine: false,
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const { token, fee, beneficiary } = schemeConfig.params
       return [token, fee, beneficiary] // TODO
@@ -172,14 +157,8 @@ export const schemes: Scheme[] = [
     description: "Enables the DAO to upgrade itself.",
     toggleDefault: true,
     permissions: "0x0000000A" /* manage schemes + upgrade controller */,
-    params: [
-      {
-        typeName: "votingMachineConfig",
-        valueType: "VotingMachineConfig",
-        displayName: "Voting Machine Configuration",
-        description: "VotingMachine",
-      },
-    ],
+    params: [],
+    hasVotingMachine: true,
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const {
         votingMachineParametersKey,
@@ -195,14 +174,8 @@ export const schemes: Scheme[] = [
       "Manages post-creation adding/modifying and removing of features. Features add functionality to the DAO.",
     toggleDefault: true,
     permissions: "0x0000001F" /* all permissions */,
-    params: [
-      {
-        typeName: "votingMachineConfig",
-        valueType: "VotingMachineConfig",
-        displayName: "Voting Machine Configuration",
-        description: "VotingMachine",
-      },
-    ],
+    hasVotingMachine: true,
+    params: [],
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const {
         votingMachineParametersKey,
@@ -221,15 +194,9 @@ export const schemes: Scheme[] = [
     description:
       'Makes it possible to add/modify and remove constraints for the DAO. A constraint defines what "cannot be done" in the DAO. For instance, limit the number of tokens that a DAO can create.',
     toggleDefault: true,
+    hasVotingMachine: true,
     permissions: "0x00000004" /* manage global constraints */,
-    params: [
-      {
-        typeName: "votingMachineConfig",
-        valueType: "VotingMachineConfig",
-        displayName: "Voting Machine Configuration",
-        description: "VotingMachine",
-      },
-    ],
+    params: [],
     getCallableParamsArray: function(schemeConfig, deploymentInfo) {
       const {
         votingMachineParametersKey,
@@ -241,7 +208,7 @@ export const schemes: Scheme[] = [
 ]
 
 export const getScheme = (typeName: string) =>
-  R.find(scheme => scheme.typeName === typeName, schemes) as Scheme
+  R.find(scheme => scheme.typeName === typeName, schemes) as SchemeDefinition
 
 export const getSchemeCallableParamsArray = (
   schemeConfig: SchemeConfig,

--- a/src/lib/integrations/daoStack/arc/typeConversions.ts
+++ b/src/lib/integrations/daoStack/arc/typeConversions.ts
@@ -3,9 +3,9 @@ import * as R from "ramda"
 import {
   DAO,
   Founder,
-  Scheme,
-  VotingMachine,
-  VotingMachineConfiguration,
+  SchemeDefinition,
+  VotingMachineDefinition,
+  VotingMachineConfig,
 } from "./types"
 
 const toFounderConfigs = (founders: Founder[]): any[] =>
@@ -23,7 +23,7 @@ const toFounderConfigs = (founders: Founder[]): any[] =>
   )
 
 const toVotingMachineParams = (
-  votingMachineConfiguration: VotingMachineConfiguration
+  votingMachineConfiguration: VotingMachineConfig
 ) => ({
   votingMachineParams: {
     votingMachineName: votingMachineConfiguration.typeName,

--- a/src/lib/integrations/daoStack/arc/types.ts
+++ b/src/lib/integrations/daoStack/arc/types.ts
@@ -9,28 +9,22 @@ export type ParamConfig = {
   [paramName: string]: string | number
 }
 
-export type VotingMachineConfiguration = {
+export type VotingMachineConfig = {
   typeName: string
   params: ParamConfig
 }
 
-export type VotingMachine = {
+export type VotingMachineDefinition = {
   typeName: string
   displayName: string
   description: string
-  params: Param[]
-  getCallableParamsArray: (config: VotingMachineConfiguration) => any[]
+  params: ParamDefinition[]
+  getCallableParamsArray: (config: VotingMachineConfig) => any[]
 }
 
-export type Param = {
+export type ParamDefinition = {
   typeName: string
-  valueType:
-    | "boolean"
-    | "string"
-    | "number"
-    | "Address"
-    | "BigNumber"
-    | "VotingMachineConfig"
+  valueType: "boolean" | "string" | "number" | "Address" | "BigNumber"
   displayName: string
   description: string
   defaultValue?: string | number | boolean
@@ -46,23 +40,23 @@ export type Founder = {
 export type SchemeConfig = {
   id: string
   typeName: string // not schemeTypeName (that is in use now)
-  params: ParamConfig & {
-    votingMachineConfig: VotingMachineConfiguration | null
-  }
+  votingMachineConfig?: VotingMachineConfig
+  params: ParamConfig
 }
 
-export type Scheme = {
+export type SchemeDefinition = {
   typeName: string
   address?: string
   displayName: string
   description: string
   toggleDefault: boolean
   permissions: string
+  hasVotingMachine: boolean
   getCallableParamsArray: (
     schemeConfig: SchemeConfig,
     deploymentInfo: DeploymentInfo
   ) => any[]
-  params: Param[]
+  params: ParamDefinition[]
 }
 
 export type DAO = {

--- a/src/lib/integrations/daoStack/arc/votingMachines.ts
+++ b/src/lib/integrations/daoStack/arc/votingMachines.ts
@@ -1,8 +1,12 @@
-import { VotingMachine, Param, VotingMachineConfiguration } from "./types"
+import {
+  VotingMachineDefinition,
+  ParamDefinition,
+  VotingMachineConfig,
+} from "./types"
 import Web3 from "web3"
 import * as R from "ramda"
 
-export const votingMachines: { [key: string]: VotingMachine } = {
+export const votingMachines: { [key: string]: VotingMachineDefinition } = {
   AbsoluteVote: {
     typeName: "AbsoluteVote",
     displayName: "Absolute Vote",
@@ -24,7 +28,7 @@ export const votingMachines: { [key: string]: VotingMachine } = {
         defaultValue: 50,
       },
     ],
-    getCallableParamsArray: ({ params }: VotingMachineConfiguration) => {
+    getCallableParamsArray: ({ params }: VotingMachineConfig) => {
       return [params["votePerc"], params["voteOnBehalf"]]
     },
   },
@@ -201,7 +205,7 @@ export const votingMachines: { [key: string]: VotingMachine } = {
         defaultValue: 1,
       },
     ],
-    getCallableParamsArray: ({ params }: VotingMachineConfiguration) => {
+    getCallableParamsArray: ({ params }: VotingMachineConfig) => {
       return [
         [
           params["queuedVoteRequiredPercentage"],
@@ -231,7 +235,7 @@ export const votingMachines: { [key: string]: VotingMachine } = {
 }
 
 export const getVotingMachineDefaultParams = (typeName: string): any => {
-  const votingMachine = votingMachines[typeName] as VotingMachine
+  const votingMachine = votingMachines[typeName] as VotingMachineDefinition
 
   return R.reduce(
     (acc, param) => R.assoc(param.typeName, param.defaultValue, acc),
@@ -243,7 +247,7 @@ export const getVotingMachineDefaultParams = (typeName: string): any => {
 export const getVotingMachine = (typeName: string) => votingMachines[typeName]
 
 export const getVotingMachineCallableParamsArray = (
-  votingMachineConfig: VotingMachineConfiguration
+  votingMachineConfig: VotingMachineConfig
 ) =>
   getVotingMachine(votingMachineConfig.typeName).getCallableParamsArray(
     votingMachineConfig

--- a/src/lib/integrations/daoStack/arc/votingMachines.ts
+++ b/src/lib/integrations/daoStack/arc/votingMachines.ts
@@ -6,7 +6,9 @@ import {
 import Web3 from "web3"
 import * as R from "ramda"
 
-export const votingMachines: { [key: string]: VotingMachineDefinition } = {
+export const votingMachineDefinitions: {
+  [key: string]: VotingMachineDefinition
+} = {
   AbsoluteVote: {
     typeName: "AbsoluteVote",
     displayName: "Absolute Vote",
@@ -235,7 +237,9 @@ export const votingMachines: { [key: string]: VotingMachineDefinition } = {
 }
 
 export const getVotingMachineDefaultParams = (typeName: string): any => {
-  const votingMachine = votingMachines[typeName] as VotingMachineDefinition
+  const votingMachine = votingMachineDefinitions[
+    typeName
+  ] as VotingMachineDefinition
 
   return R.reduce(
     (acc, param) => R.assoc(param.typeName, param.defaultValue, acc),
@@ -244,11 +248,12 @@ export const getVotingMachineDefaultParams = (typeName: string): any => {
   )
 }
 
-export const getVotingMachine = (typeName: string) => votingMachines[typeName]
+export const getVotingMachineDefinition = (typeName: string) =>
+  votingMachineDefinitions[typeName]
 
 export const getVotingMachineCallableParamsArray = (
   votingMachineConfig: VotingMachineConfig
 ) =>
-  getVotingMachine(votingMachineConfig.typeName).getCallableParamsArray(
-    votingMachineConfig
-  )
+  getVotingMachineDefinition(
+    votingMachineConfig.typeName
+  ).getCallableParamsArray(votingMachineConfig)


### PR DESCRIPTION
Still needs quite a bit of work, the problem I was running into was having the voting machine configs use the same form validation object because of the switch in type from `Params` to `VotingMachineParams`. 

@sogasg do you think having separate  `formError` objects with different event handlers make sense? Also some of the `valueTypes` set inside of voting machines don't map to an explicit type...

Solves #86 