### PR TITLE
Set default scheme parmas in state ("fix deployment")

### DIFF
--- a/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
+++ b/src/components/pages/DAOcreator/SchemesStep/AddSchemeDialog.tsx
@@ -24,6 +24,7 @@ import * as R from "ramda"
 import * as React from "react"
 import {
   getScheme,
+  getSchemeDefaultParams,
   getVotingMachine,
   getVotingMachineDefaultParams,
   schemes,
@@ -166,9 +167,11 @@ class VerticalLinearStepper extends React.Component<Props, State> {
 
   setSchemeType = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const { schemeConfig } = this.state
-    const { id, params } = schemeConfig
+    const { id } = schemeConfig
+    const schemeTypeName = event.target.value
+    const params = getSchemeDefaultParams(schemeTypeName)
     this.setState({
-      schemeConfig: { id, typeName: event.target.value, params },
+      schemeConfig: { id, typeName: schemeTypeName, params },
     })
   }
 
@@ -269,11 +272,7 @@ class VerticalLinearStepper extends React.Component<Props, State> {
                     label={param.displayName}
                     margin="normal"
                     onChange={this.handleSchemeConfigParamsChange}
-                    value={R.pathOr(
-                      param.defaultValue,
-                      [param.typeName],
-                      schemeConfig.params
-                    )}
+                    value={R.prop(param.typeName, schemeConfig.params)}
                     onBlur={() => console.log("TODO: validate fields")}
                     fullWidth
                     required={!R.pathOr(false, ["optional"], param)}

--- a/src/lib/integrations/daoStack/arc/createDao.ts
+++ b/src/lib/integrations/daoStack/arc/createDao.ts
@@ -76,7 +76,7 @@ export const createDao = async (
 
   const Avatar = await forgeOrg.call()
   let tx = await forgeOrg.send()
-  console.log("Created new organization.")
+  console.log("Created new organization. With avatar address: " + Avatar)
   console.log(tx)
 
   const avatar = new web3.eth.Contract(

--- a/src/lib/integrations/daoStack/arc/schemes.ts
+++ b/src/lib/integrations/daoStack/arc/schemes.ts
@@ -233,3 +233,13 @@ export const getSchemeCallableParamsArray = (
     schemeConfig,
     deploymentInfo
   )
+
+export const getSchemeDefaultParams = (typeName: string): any => {
+  const scheme = getScheme(typeName)
+
+  return R.reduce(
+    (acc, param) => R.assoc(param.typeName, param.defaultValue, acc),
+    {},
+    scheme.params
+  )
+}


### PR DESCRIPTION
Closes #103.

Propagate the default parameters to state. So that the user does not have to change the param in order for it to be included in the state.