### PR TITLE
Remove absolute URL from DAOCreator card

### DIFF
--- a/src/components/pages/Landing/index.tsx
+++ b/src/components/pages/Landing/index.tsx
@@ -62,7 +62,7 @@ const Landing: React.SFC<Props> = ({ classes }) => (
               title={"DAOcreator"}
               description={"Wizard for DAO design and deployment."}
               github={"https://github.com/dOrgTech/DAOcreator"}
-              test={"https://dorg.tech/#/dao-creator"}
+              test={"/#/dao-creator"}
             />
           </Grid>
           <Grid item xs={3} className={classes.caseCard}>


### PR DESCRIPTION
A minor inconvenience. When running locally, the DAOCreator link opens on the live website because of the absolute URL, which means a developer needs to manually change the URL to the dao creator. Making it relative to the current home will open it on whatever url and port npm spun up, i.e. `localhost:3000/#/dao-creator`.