### PR TITLE
issue 212 Date picker now validates if time picked is previous than now

### DIFF
--- a/src/components/common/FormField/index.tsx
+++ b/src/components/common/FormField/index.tsx
@@ -316,6 +316,7 @@ const DateTimeFieldView = observer(
         variant={"dialog"}
         inputVariant={"filled"}
         ampm={false}
+        error={field.hasError}
         style={{
           marginTop: "5px",
           marginBottom: "4px"
@@ -324,6 +325,7 @@ const DateTimeFieldView = observer(
           startAdornment: FieldInformation(popupState)
         }}
       />
+      <FieldError field={field} />
     </MuiPickersUtilsProvider>
   )
 );


### PR DESCRIPTION
Material UI not disabling past times is a known issue. Added a warning in case of picking a past time.